### PR TITLE
Show the popover from the button's superview instead of the window.

### DIFF
--- a/Pod/Classes/MagnetPopoverView.h
+++ b/Pod/Classes/MagnetPopoverView.h
@@ -11,21 +11,16 @@
 @interface MagnetPopoverView : UIView
 
 @property CGFloat horizontalPadding;
-
 @property CGFloat verticalPadding;
-
 @property CGFloat arrowHeight;
-
 @property CGFloat arrowWidth;
 
 @property (nonatomic, readonly) UIView *contentView;
 
 - (instancetype)initWithContentView:(UIView *)contentView;
 
-- (void)showPopover:(CGRect)targetRect;
-
+- (void)showPopoverFromButton:(UIButton *)button;
 - (void)dismissPopover;
-
 - (BOOL)isVisible;
 
 @end

--- a/Pod/Classes/MagnetPopoverView.m
+++ b/Pod/Classes/MagnetPopoverView.m
@@ -12,26 +12,17 @@
 @interface MagnetPopoverView()
 
 @property UIGestureRecognizer *tapRecognizer;
-
 @property UIView *containerView;
-
 @property CGRect targetRect;
 
 @end
 
 @implementation MagnetPopoverView
 
-/*
-// Only override drawRect: if you perform custom drawing.
-// An empty implementation adversely affects performance during animation.
-- (void)drawRect:(CGRect)rect {
-    // Drawing code
-}
-*/
-
-
-- (instancetype)initWithContentView:(UIView *)contentView {
-    if(self = [super initWithFrame:CGRectNull]) {
+- (instancetype)initWithContentView:(UIView *)contentView
+{
+    if (self = [super initWithFrame:CGRectNull])
+    {
         self->_contentView = contentView;
         self.verticalPadding = 5.0;
         self.horizontalPadding = 5.0;
@@ -116,20 +107,20 @@
     }];
 }
 
-- (BOOL)isVisible {
+- (BOOL)isVisible
+{
     return self.superview != nil;
 }
 
-
-
-- (void)showPopover:(CGRect)targetRect {
+- (void)showPopoverFromButton:(UIButton *)button
+{
     [self resetSize];
-    self.targetRect = targetRect;
+    self.targetRect = button.frame;
     CGPoint position = [self findPositionWithTarget];
     CGRect frame = CGRectMake(position.x, position.y, self.frame.size.width, self.frame.size.height);
     self.frame = frame;
     self.alpha = 0;
-    [[[[UIApplication sharedApplication] delegate] window] addSubview:self];
+    [button.superview addSubview:self];
     [self setEvents];
     [UIView beginAnimations:nil context:nil];
     [UIView setAnimationDuration:0.2];

--- a/Pod/Classes/MagnetPopupPickerButton.h
+++ b/Pod/Classes/MagnetPopupPickerButton.h
@@ -25,9 +25,14 @@
 
 @property (nonatomic, weak) id<PopupPickerButtonStateDelegate> stateDelegate;
 
--(void)setOptions:(NSArray *)list keyNames:(MagnetKeyValuePair *)names;
--(void)setSelectedValue:(NSString *)value;
--(void)clearValue;
+- (void)setOptions:(NSArray *)list keyNames:(MagnetKeyValuePair *)names;
+- (void)setSelectedValue:(NSString *)value;
+- (void)clearValue;
+
+/**
+ Dismisses the popover if it's open.
+ */
+- (void)dismissPopover;
 
 - (NSString *)selectedKey;
 - (id)selectedValue;

--- a/Pod/Classes/MagnetPopupPickerButton.h
+++ b/Pod/Classes/MagnetPopupPickerButton.h
@@ -11,7 +11,7 @@
 
 @protocol PopupPickerButtonStateDelegate
 
--(void)popupPickerButtonValueChanged:(id)sender;
+- (void)popupPickerButtonValueChanged:(id)sender;
 
 @end
 
@@ -19,23 +19,17 @@
 @interface MagnetPopupPickerButton : UIButton<UIPopoverControllerDelegate, MagnetPickerViewControllerDelegate>
 
 @property CGSize pickerSize;
-
 @property UIColor *popoverColor;
-
 @property MagnetPickerViewController *pickerController;
-
 @property MagnetKeyValuePair *selectedPair;
 
-@property (nonatomic,weak) id<PopupPickerButtonStateDelegate> stateDelegate;
+@property (nonatomic, weak) id<PopupPickerButtonStateDelegate> stateDelegate;
 
 -(void)setOptions:(NSArray *)list keyNames:(MagnetKeyValuePair *)names;
-
 -(void)setSelectedValue:(NSString *)value;
-
 -(void)clearValue;
 
--(NSObject *)fieldValue;
-
--(NSObject *)fieldText;
+- (NSString *)selectedKey;
+- (id)selectedValue;
 
 @end

--- a/Pod/Classes/MagnetPopupPickerButton.m
+++ b/Pod/Classes/MagnetPopupPickerButton.m
@@ -100,15 +100,22 @@
     
 }
 
-- (NSObject *)fieldText {
-    return self.selectedPair.value;
-}
-
-- (NSObject *)fieldValue {
+- (NSString *)selectedKey
+{
     return self.selectedPair.key;
 }
 
-- (void)openPopover:(UIButton *)button {
+- (id)selectedValue
+{
+    id fieldText = self.selectedPair.value;
+    if (!fieldText)
+        fieldText = self.titleLabel.text;
+    
+    return fieldText;
+}
+
+- (void)openPopover:(UIButton *)button
+{
     if([self.popover isVisible]) {
         [self.popover dismissPopover];
         return;

--- a/Pod/Classes/MagnetPopupPickerButton.m
+++ b/Pod/Classes/MagnetPopupPickerButton.m
@@ -82,6 +82,12 @@
     [self setTitle:self.placeholder forState:UIControlStateNormal];
 }
 
+- (void)dismissPopover
+{
+    if (self.popover.isVisible)
+        [self.popover dismissPopover];
+}
+
 - (void)pickerViewController:(id)sender submitClicked:(MagnetKeyValuePair *)selected {
     self.selectedPair = selected;
     [self.pickerController resetSearch];

--- a/Pod/Classes/MagnetPopupPickerButton.m
+++ b/Pod/Classes/MagnetPopupPickerButton.m
@@ -117,16 +117,7 @@
     self.popover = [[MagnetPopoverView alloc] initWithContentView:self.pickerController.view];
     [self.pickerController selectFirstElement];
     self.popover.backgroundColor = self.popoverColor;
-    [self.popover showPopover:self.frame];
+    [self.popover showPopoverFromButton:self];
 }
-
-/*
-// Only override drawRect: if you perform custom drawing.
-// An empty implementation adversely affects performance during animation.
-- (void)drawRect:(CGRect)rect
-{
-    // Drawing code
-}
-*/
 
 @end


### PR DESCRIPTION
The popover is now added to the button's superview instead of the app's window.

This fixes the issue where the popover would appear in a weird frame if the button lives in a scroll view or a view controller with a nav bar or tab bar.

It also makes it so that the popover will be added to the view hierarchy as any good UI object should be.
